### PR TITLE
Multi-process & shared-DB correctness (#58, #59, #60)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,24 @@ you retain ownership of your contribution.
 - No docstrings or comments on unchanged code
 - Error handling via `anyhow` for application code
 
+## Database migrations
+
+One remote database may be shared by several replicas — across projects and even
+across machines — that each migrate independently and sync the result. Every new
+migration in `src/migrations.rs` MUST be additive and idempotent:
+
+- Create with `CREATE TABLE/INDEX IF NOT EXISTS`.
+- Add columns with `ALTER TABLE ... ADD COLUMN` guarded against the
+  `"duplicate column name"` error (see `apply_v002`).
+- Never emit unconditional seed-data `INSERT`s; use `INSERT OR IGNORE` or an
+  idempotent `UPDATE ... WHERE` backfill.
+- Avoid destructive renames; prefer add-new + backfill so an older `coree`
+  binary sharing the schema keeps working. A shared remote DB implies a shared
+  schema version, so schema changes must stay forward-compatible.
+
+Never edit the SQL of a migration that has already shipped — checksums are
+validated and existing installs have already applied it. Add a new migration.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the

--- a/docs/user/config.md
+++ b/docs/user/config.md
@@ -128,7 +128,9 @@ Controls the code intelligence index.
 mode = "managed"  # default
 ```
 
-Accepts the same values as `memory.mode`. Use `disabled` to turn off code indexing entirely.
+Accepts `managed` (default), `local`, or `disabled`. Use `disabled` to turn off code indexing entirely.
+
+`remote` is **not supported** for the index and must not be shared across projects: the code index is a rebuildable, per-checkout derivative of the working tree, so `project_id` is not a meaningful discriminator for it. A `remote` index configuration (including `COREE__INDEX__REMOTE_URL` / `COREE__INDEX__REMOTE_AUTH_TOKEN`) is coerced to `managed` with a warning. Memory storage is unaffected and may be `remote`.
 
 #### `git_history`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -214,7 +214,32 @@ impl Config {
         } else {
             validate_project_root(cfg.project_root.as_deref().unwrap())?;
         }
+        cfg.normalize_index_storage();
         Ok(cfg)
+    }
+
+    /// The code index is a rebuildable, per-checkout, write-heavy derivative of the
+    /// working tree; `project_id` is not a meaningful discriminator for code, so it
+    /// must never be shared via a remote database. Remote storage is also not
+    /// implemented for the index — it is always opened as a local file — so a remote
+    /// configuration would be silently ignored. Coerce any remote index storage to
+    /// managed-local and warn, leaving the memory storage untouched.
+    fn normalize_index_storage(&mut self) {
+        let s = &self.index.storage;
+        let configured_remote = s.mode == StorageMode::Remote
+            || s.remote_url.is_some()
+            || s.remote_auth_token.is_some();
+        if configured_remote {
+            eprintln!(
+                "[coree] Remote/shared storage is not supported for the code index \
+                 (it is rebuildable per-checkout); using managed-local storage for the \
+                 index instead. Memory storage is unaffected."
+            );
+            self.index.storage.mode = StorageMode::Managed;
+            self.index.storage.remote_mode = RemoteMode::default();
+            self.index.storage.remote_url = None;
+            self.index.storage.remote_auth_token = None;
+        }
     }
 
     /// Resolved DB path for the current memory storage mode.
@@ -430,6 +455,64 @@ mod tests {
         assert!(path.ends_with("memory.db"));
         assert!(path.to_string_lossy().contains("coree"));
         assert!(path.to_string_lossy().contains("-some-project"));
+    }
+
+    #[test]
+    fn normalize_index_storage_coerces_remote_to_managed() {
+        let mut cfg = Config {
+            project_root: Some(PathBuf::from("/some/project")),
+            index: IndexConfig {
+                storage: StorageConfig {
+                    mode: StorageMode::Remote,
+                    remote_url: Some("libsql://shared.turso.io".to_string()),
+                    remote_auth_token: Some("secret".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            // Memory remote config must survive normalization untouched.
+            memory: MemoryConfig {
+                storage: StorageConfig {
+                    mode: StorageMode::Remote,
+                    remote_url: Some("libsql://mem.turso.io".to_string()),
+                    ..Default::default()
+                },
+            },
+            ..Default::default()
+        };
+        cfg.normalize_index_storage();
+
+        assert_eq!(cfg.index.storage.mode, StorageMode::Managed);
+        assert!(cfg.index.storage.remote_url.is_none());
+        assert!(cfg.index.storage.remote_auth_token.is_none());
+        // index_db_path is a local managed path, never remote.
+        assert!(cfg.index_db_path().ends_with("index.db"));
+
+        // Memory storage is untouched.
+        assert_eq!(cfg.memory.storage.mode, StorageMode::Remote);
+        assert_eq!(
+            cfg.memory.storage.remote_url.as_deref(),
+            Some("libsql://mem.turso.io")
+        );
+    }
+
+    #[test]
+    fn normalize_index_storage_leaves_managed_and_disabled() {
+        for mode in [StorageMode::Managed, StorageMode::Local, StorageMode::Disabled] {
+            let mut cfg = Config {
+                project_root: Some(PathBuf::from("/some/project")),
+                index: IndexConfig {
+                    storage: StorageConfig {
+                        mode: mode.clone(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            cfg.normalize_index_storage();
+            assert_eq!(cfg.index.storage.mode, mode);
+        }
     }
 
     #[test]

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -1,3 +1,24 @@
+//! Schema migrations for the memory database.
+//!
+//! Migrations run on every `coree serve` startup against the local (possibly
+//! replica) database. One remote database may be shared by several replicas —
+//! across projects and even across machines — that each migrate independently
+//! and sync the resulting frames. To stay correct under that concurrency, every
+//! migration MUST be additive and idempotent:
+//!
+//! - Create with `CREATE TABLE/INDEX IF NOT EXISTS`.
+//! - Add columns with `ALTER TABLE ... ADD COLUMN` guarded against the
+//!   `"duplicate column name"` error (see [`apply_v002`]).
+//! - Never emit unconditional seed-data `INSERT`s; use `INSERT OR IGNORE`, or
+//!   backfill with an idempotent `UPDATE ... WHERE` (see [`apply_v002`]).
+//! - Avoid destructive renames; prefer add-new + backfill so an older `coree`
+//!   binary sharing the schema keeps working (additive changes are
+//!   forward-compatible; a shared remote DB implies a shared schema version).
+//!
+//! Do NOT edit the SQL of a migration that has already shipped: [`validate_checksum`]
+//! hashes each migration's `sql` and warns on mismatch, and existing installs have
+//! already applied it. Add a new migration instead.
+
 use anyhow::Result;
 use chrono::Utc;
 use sha2::{Digest, Sha256};
@@ -82,8 +103,15 @@ async fn apply(conn: &Connection, migration: &Migration) -> Result<()> {
 
     let checksum = sha256(migration.sql);
     let now = Utc::now().to_rfc3339();
+    // INSERT OR IGNORE, not plain INSERT: when several replicas share one remote
+    // database they each apply migrations against their own local replica and push
+    // the resulting frames. `name` is the PRIMARY KEY, so two replicas recording
+    // the same migration would otherwise collide on merge. Ignoring a duplicate is
+    // correct because the DDL above is idempotent — the row is pure bookkeeping.
+    // This is a code-only change; it does not alter any migration's `sql`, so the
+    // checksums validated in `validate_checksum` are unaffected.
     conn.execute(
-        "INSERT INTO schema_migrations (name, applied_at, checksum) VALUES (?1, ?2, ?3)",
+        "INSERT OR IGNORE INTO schema_migrations (name, applied_at, checksum) VALUES (?1, ?2, ?3)",
         (migration.name, now, checksum),
     )
     .await?;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -17,9 +17,10 @@ use rmcp::{
     transport::stdio,
 };
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, PickFirst, json::JsonString, serde_as};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::Mutex;
 use turso::Connection;
 use uuid::Uuid;
@@ -28,7 +29,7 @@ use crate::{
     config::{Config, RemoteMode, StorageMode},
     db::{self, Db},
     embed::Embedder,
-    index, migrations, project_id, remote, retrieve,
+    index, migrations, project_id, remote, request, retrieve,
     store::{self, WriteLock},
 };
 
@@ -63,6 +64,11 @@ struct CoreeServer {
     session_id: String,
     project_id: String,
     config: Arc<Config>,
+    /// True once this process has acquired serve.lock and owns the database.
+    /// While false, this is a secondary process: tool calls are forwarded to the
+    /// primary over the local socket instead of being served from a local DB
+    /// (which a secondary never opens).
+    is_primary: Arc<AtomicBool>,
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
     #[allow(dead_code)]
@@ -83,6 +89,37 @@ impl CoreeServer {
             DbState::Failed(msg) => Err(format!(
                 "coree database initialisation failed: {msg} — call the `diagnose` tool for remediation steps."
             )),
+        }
+    }
+
+    /// If this process is a secondary (has not acquired serve.lock), forward the
+    /// tool call to the primary over the local socket and return its result.
+    /// Returns `None` when this process is the primary (handle locally) or when the
+    /// primary is unreachable — in the latter case the caller falls through to local
+    /// handling, which surfaces the `try_ready()` syncing state until this process
+    /// is itself promoted to primary.
+    ///
+    /// `input` is re-serialized to the same JSON argument object the MCP client sent;
+    /// the primary re-deserializes it with the identical serde_as rules, so values
+    /// round-trip. Pass `None` for tools that take no arguments.
+    async fn maybe_proxy<T: Serialize>(
+        &self,
+        tool: &str,
+        input: Option<&T>,
+    ) -> Option<Result<String, String>> {
+        if self.is_primary.load(Ordering::SeqCst) {
+            return None;
+        }
+        let args = match input {
+            Some(v) => match serde_json::to_string(v) {
+                Ok(s) => Some(s),
+                Err(e) => return Some(Err(tool_err(format!("proxy serialize failed: {e}")))),
+            },
+            None => None,
+        };
+        match request::call_tool_on_server(&self.config, tool, args.as_deref()).await {
+            Ok(Some(text)) => Some(Ok(text)),
+            _ => None,
         }
     }
 
@@ -108,7 +145,7 @@ impl CoreeServer {
 // back to parsing from a string, accepting both forms transparently.
 
 #[serde_as]
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct StoreMemoryInput {
     /// Full text of the memory to store.
     content: String,
@@ -153,7 +190,7 @@ struct StoreMemoryInput {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct SearchMemoryInput {
     /// Natural language search query.
     query: String,
@@ -172,7 +209,7 @@ struct SearchMemoryInput {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct GetMemoriesInput {
     /// IDs of memories to fetch in full.
     // Claude Code MCP client sends arrays as JSON-encoded strings - see comment above.
@@ -182,7 +219,7 @@ struct GetMemoriesInput {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct StoreMemoriesInput {
     /// Array of memories to store. Each follows the same schema as a single store call.
     // Claude Code MCP client sends arrays as JSON-encoded strings - see comment above.
@@ -192,7 +229,7 @@ struct StoreMemoriesInput {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct DeleteMemoriesInput {
     /// IDs of memories to delete.
     // Claude Code MCP client sends arrays as JSON-encoded strings - see comment above.
@@ -202,7 +239,7 @@ struct DeleteMemoriesInput {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct ListMemoriesInput {
     /// Project scope. Omit to use the server's configured project_id.
     #[serde(default)]
@@ -228,7 +265,7 @@ struct ListMemoriesInput {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct PinMemoriesInput {
     /// IDs of memories to pin or unpin.
     // Claude Code MCP client sends arrays as JSON-encoded strings - see comment above.
@@ -245,7 +282,7 @@ struct PinMemoriesInput {
 // --- Code intelligence tool input schemas ---
 
 #[serde_as]
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct SearchCodeInput {
     /// Natural language query describing the code you are looking for.
     query: String,
@@ -256,7 +293,7 @@ struct SearchCodeInput {
     limit: Option<usize>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct GetSymbolInput {
     /// Symbol name or qualified path to look up (e.g. "validate_jwt_token" or "Auth::validate").
     name: String,
@@ -266,7 +303,7 @@ struct GetSymbolInput {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct SearchInput {
     /// Natural language query to search across memories and source code simultaneously.
     query: String,
@@ -277,14 +314,14 @@ struct SearchInput {
     limit: Option<usize>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct SeedCloudInput {
     /// Overwrite remote database even if it already has data.
     #[serde(default)]
     force: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 struct MigrateToTursoInput {
     /// Turso database URL (e.g. libsql://mydb-org.turso.io). Leave empty to be prompted interactively.
     #[serde(default)]
@@ -337,6 +374,9 @@ impl CoreeServer {
         &self,
         Parameters(input): Parameters<StoreMemoriesInput>,
     ) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy("store_memories", Some(&input)).await {
+            return r;
+        }
         let ready = self.try_ready()?;
         if input.memories.is_empty() {
             return Ok("No memories provided.".to_string());
@@ -404,6 +444,9 @@ impl CoreeServer {
         &self,
         Parameters(input): Parameters<SearchMemoryInput>,
     ) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy("search_memory", Some(&input)).await {
+            return r;
+        }
         let ready = self.try_ready()?;
         let project = input.project_id.unwrap_or_else(|| self.project_id.clone());
         let limit = input.limit.unwrap_or(5);
@@ -445,6 +488,9 @@ impl CoreeServer {
         &self,
         Parameters(input): Parameters<GetMemoriesInput>,
     ) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy("get_memories", Some(&input)).await {
+            return r;
+        }
         let ready = self.try_ready()?;
         if input.ids.is_empty() {
             return Ok("No IDs provided.".to_string());
@@ -557,6 +603,9 @@ impl CoreeServer {
         &self,
         Parameters(input): Parameters<ListMemoriesInput>,
     ) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy("list_memories", Some(&input)).await {
+            return r;
+        }
         let ready = self.try_ready()?;
         let project = input.project_id.unwrap_or_else(|| self.project_id.clone());
         let limit = input.limit.unwrap_or(20);
@@ -589,6 +638,9 @@ impl CoreeServer {
         &self,
         Parameters(input): Parameters<PinMemoriesInput>,
     ) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy("pin_memories", Some(&input)).await {
+            return r;
+        }
         let ready = self.try_ready()?;
         if input.ids.is_empty() {
             return Ok("No IDs provided.".to_string());
@@ -614,6 +666,9 @@ impl CoreeServer {
         &self,
         Parameters(input): Parameters<SeedCloudInput>,
     ) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy("remote_sync", Some(&input)).await {
+            return r;
+        }
         remote::sync(&self.config, input.force.unwrap_or(false))
             .await
             .map_err(|e| tool_err(format!("remote_sync failed: {e}")))
@@ -624,6 +679,9 @@ impl CoreeServer {
         &self,
         Parameters(input): Parameters<DeleteMemoriesInput>,
     ) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy("delete_memories", Some(&input)).await {
+            return r;
+        }
         let ready = self.try_ready()?;
         if input.ids.is_empty() {
             return Ok("No IDs provided.".to_string());
@@ -645,6 +703,9 @@ impl CoreeServer {
         description = "List memories eligible for eviction: not pinned, older than 7 days, retention score below threshold. Call before evict_stale_memories to review candidates."
     )]
     async fn list_stale_memories(&self) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy::<()>("list_stale_memories", None).await {
+            return r;
+        }
         let ready = self.try_ready()?;
         match retrieve::list_stale(&ready.conn, &self.project_id).await {
             Ok(stale) if stale.is_empty() => Ok("No stale memories found.".to_string()),
@@ -668,6 +729,9 @@ impl CoreeServer {
         Returns a 'loading' message if the database is not yet ready — wait a few seconds and retry."
     )]
     async fn session_context(&self) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy::<()>("session_context", None).await {
+            return r;
+        }
         let ready = self.try_ready()?;
         crate::inject::build_tool_session_content(&ready.conn, &self.project_id)
             .await
@@ -678,6 +742,9 @@ impl CoreeServer {
         description = "Permanently purge all stale memories and their vectors. Irreversible. Call list_stale_memories first to review candidates."
     )]
     async fn evict_stale_memories(&self) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy::<()>("evict_stale_memories", None).await {
+            return r;
+        }
         let ready = self.try_ready()?;
         match retrieve::evict_stale(&ready.conn, &self.project_id).await {
             Ok(0) => Ok("No stale memories to evict.".to_string()),
@@ -799,6 +866,9 @@ impl CoreeServer {
         &self,
         Parameters(input): Parameters<SearchCodeInput>,
     ) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy("search_code", Some(&input)).await {
+            return r;
+        }
         let db_ready = self.try_ready()?;
         let idx = self.try_index_ready()?;
         let limit = input.limit.unwrap_or(10);
@@ -842,6 +912,9 @@ impl CoreeServer {
         &self,
         Parameters(input): Parameters<GetSymbolInput>,
     ) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy("get_symbol", Some(&input)).await {
+            return r;
+        }
         let idx = self.try_index_ready()?;
         let results = index::search::get_symbol(&idx.conn, &input.name, input.file_path.as_deref())
             .await
@@ -954,6 +1027,9 @@ impl CoreeServer {
         description = "Search memories, source code, and git history simultaneously. Use this by default. Returns memory results and code results in separate sections."
     )]
     async fn search(&self, Parameters(input): Parameters<SearchInput>) -> Result<String, String> {
+        if let Some(r) = self.maybe_proxy("search", Some(&input)).await {
+            return r;
+        }
         let t_search = std::time::Instant::now();
         let db_ready = self.try_ready()?;
         let limit = input.limit.unwrap_or(5);
@@ -1256,6 +1332,10 @@ async fn serve_inner(config: Config, project_id: String) -> Result<()> {
     let session_id = Uuid::new_v4().to_string();
     mlog!("coree: session {session_id}, project \"{project_id}\"");
 
+    // Flipped to true by the background task once this process wins serve.lock.
+    // Until then this is a secondary and tool handlers proxy to the primary.
+    let is_primary = Arc::new(AtomicBool::new(false));
+
     let server = CoreeServer {
         db: db_rx,
         idx: idx_rx,
@@ -1263,6 +1343,7 @@ async fn serve_inner(config: Config, project_id: String) -> Result<()> {
         session_id,
         project_id: project_id.clone(),
         config: Arc::new(config.clone()),
+        is_primary: Arc::clone(&is_primary),
         tool_router: CoreeServer::tool_router(),
         prompt_router: CoreeServer::prompt_router(),
     };
@@ -1278,7 +1359,6 @@ async fn serve_inner(config: Config, project_id: String) -> Result<()> {
     let idx_tx_clone = idx_tx.clone();
     let server_for_socket = server.clone();
     let ready_file_bg = ready_file.clone();
-    let is_primary = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let is_primary_bg = Arc::clone(&is_primary);
 
     let lock_file_path_bg = lock_file_path.clone();
@@ -1688,4 +1768,64 @@ fn format_full_memory(m: &retrieve::FullMemory) -> String {
         content = m.content,
         facts = facts_str,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // maybe_proxy serializes the typed tool input and the primary re-deserializes it
+    // with the same serde_as rules. These structs use serde_as deserialize helpers
+    // (PickFirst/JsonString/DisplayFromStr) that accept both native and string forms;
+    // this asserts the Serialize side produces output the Deserialize side accepts, so
+    // arguments round-trip across the proxy hop without loss.
+    fn roundtrip<T>(value: &T) -> T
+    where
+        T: Serialize + for<'de> Deserialize<'de>,
+    {
+        let json = serde_json::to_string(value).expect("serialize");
+        serde_json::from_str(&json).expect("deserialize")
+    }
+
+    #[test]
+    fn store_memories_input_roundtrips() {
+        let input = StoreMemoriesInput {
+            memories: vec![StoreMemoryInput {
+                content: "c".to_string(),
+                memory_type: "decision".to_string(),
+                title: "t".to_string(),
+                topic_key: Some("k".to_string()),
+                facts: vec!["f1".to_string(), "f2".to_string()],
+                tags: vec!["tag".to_string()],
+                importance: Some(0.9),
+                source: Some("reviewed".to_string()),
+                pinned: Some(true),
+                project_id: Some("p".to_string()),
+            }],
+        };
+        let out = roundtrip(&input);
+        assert_eq!(out.memories.len(), 1);
+        let m = &out.memories[0];
+        assert_eq!(m.facts, vec!["f1".to_string(), "f2".to_string()]);
+        assert_eq!(m.tags, vec!["tag".to_string()]);
+        assert_eq!(m.importance, Some(0.9));
+        assert_eq!(m.pinned, Some(true));
+    }
+
+    #[test]
+    fn pin_and_search_inputs_roundtrip() {
+        let pin = PinMemoriesInput {
+            ids: vec!["a".to_string(), "b".to_string()],
+            pin: true,
+        };
+        let out = roundtrip(&pin);
+        assert_eq!(out.ids.len(), 2);
+        assert!(out.pin);
+
+        let search = SearchInput {
+            query: "q".to_string(),
+            limit: Some(7),
+        };
+        assert_eq!(roundtrip(&search).limit, Some(7));
+    }
 }

--- a/tests/db.rs
+++ b/tests/db.rs
@@ -58,6 +58,37 @@ async fn migrations_are_idempotent() {
     coree::migrations::run(&db.conn).await.unwrap();
 }
 
+// Each migration is recorded exactly once in schema_migrations, and re-running
+// migrations (or a duplicate row arriving from another replica via INSERT OR
+// IGNORE) never produces a duplicate bookkeeping row.
+#[tokio::test]
+async fn migrations_bookkeeping_has_no_duplicates() {
+    let db = setup().await;
+    coree::migrations::run(&db.conn).await.unwrap();
+
+    // Simulate a row syncing in from another replica: INSERT OR IGNORE of an
+    // already-present migration name must be a no-op, not an error.
+    db.conn
+        .execute(
+            "INSERT OR IGNORE INTO schema_migrations (name, applied_at, checksum) \
+             VALUES ('v001_initial', 'x', 'x')",
+            (),
+        )
+        .await
+        .unwrap();
+
+    let mut rows = db
+        .conn
+        .query(
+            "SELECT COUNT(*) FROM (SELECT name FROM schema_migrations GROUP BY name HAVING COUNT(*) > 1)",
+            (),
+        )
+        .await
+        .unwrap();
+    let dupes: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    assert_eq!(dupes, 0, "schema_migrations must have no duplicate names");
+}
+
 // --- delete_batch ---
 
 #[tokio::test]


### PR DESCRIPTION
Implements the three coree concurrency issues from the multi-process / shared-DB design discussion.

## #58 Secondary serve proxies to the primary
Secondaries advertised all MCP tools but returned the "syncing" placeholder forever (handlers gate on a DB a secondary never opens). Adds `is_primary` + `maybe_proxy()` which forwards tool calls to the primary over the existing local socket. Wired into every DB/index handler; `diagnose` stays local. Tool inputs derive `Serialize` so args round-trip. **Verified end-to-end**: a secondary driven over MCP stdio returns real `search`/`session_context` results proxied from the live primary.

## #59 Conflict-free migration bookkeeping
`schema_migrations` tracking `INSERT` → `INSERT OR IGNORE` so replicas sharing a remote DB don't collide on merge. Code-only (checksum-safe). Documents the additive/idempotent convention for new migrations.

## #60 Disallow remote/shared index DB
Coerces remote index storage → managed-local with a warning at config load (the index is rebuildable per-checkout; remote was never actually implemented for it). Memory storage unaffected.

## Tests
All 125 tests pass; clippy clean (pre-existing warnings only). Adds a no-duplicate migration test, config normalization tests, and serde round-trip tests for the proxy path.

Closes #58
Closes #59
Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)